### PR TITLE
Fix keygen and metrics bug

### DIFF
--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -3,22 +3,16 @@
 
 use crate::error::Result;
 use crate::ssh::{private_key, public_key};
-use ed25519_dalek::{SecretKey, SigningKey, VerifyingKey};
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::rngs::OsRng;
-use rand::RngCore;
 
 /// Generates an ed25519 key pair and returns the public key and private key as hex strings.
 pub fn generate_key_pair() -> Result<(String, String)> {
     // Use the OS's random number generator
     let mut csprng = OsRng {};
 
-    // Generate a random secret key
-    let mut secret_key_bytes = [0u8; 32];
-    csprng.fill_bytes(&mut secret_key_bytes);
-    let secret_key = SecretKey::from(secret_key_bytes);
-
-    // Create the signing key and verifying key
-    let signing_key = SigningKey::from(secret_key);
+    // Generate signing and verifying keys directly
+    let signing_key = SigningKey::generate(&mut csprng);
     let verifying_key = VerifyingKey::from(&signing_key);
 
     // Convert the public key to a hexadecimal string
@@ -38,13 +32,8 @@ pub fn generate_openssh_key_pair(comment: Option<&str>) -> Result<(String, Strin
     // Use the OS's random number generator
     let mut csprng = OsRng {};
 
-    // Generate a random secret key
-    let mut secret_key_bytes = [0u8; 32];
-    csprng.fill_bytes(&mut secret_key_bytes);
-    let secret_key = SecretKey::from(secret_key_bytes);
-
-    // Create the signing key and verifying key
-    let signing_key = SigningKey::from(secret_key);
+    // Generate signing and verifying keys directly
+    let signing_key = SigningKey::generate(&mut csprng);
     let verifying_key = VerifyingKey::from(&signing_key);
 
     // Get the raw key bytes
@@ -54,7 +43,7 @@ pub fn generate_openssh_key_pair(comment: Option<&str>) -> Result<(String, Strin
     // Encode to OpenSSH format
     let ssh_public_key = public_key::encode_ssh_public_key(&public_key_bytes, comment)?;
     let ssh_private_key =
-        private_key::encode_ssh_private_key(&public_key_bytes, &private_key_bytes)?;
+        private_key::encode_ssh_private_key(&public_key_bytes, &private_key_bytes, comment)?;
 
     Ok((ssh_public_key, ssh_private_key))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,9 @@ pub fn stream_openssh_keys_and_match_mt(
             recv(match_receiver) -> msg => {
                 if let Ok(key_match) = msg {
                     // Update counters with the match information
-                    total_attempts += key_match.attempts;
+                    // Attempts for this thread have already been accounted for
+                    // through status updates. Only increment the match count
+                    // when a new key is found.
                     matches_found += 1;
 
                     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");

--- a/src/ssh/private_key.rs
+++ b/src/ssh/private_key.rs
@@ -8,7 +8,11 @@ use byteorder::{BigEndian, WriteBytesExt};
 
 /// Encodes an Ed25519 keypair in OpenSSH private key format.
 /// Returns a string in PEM-like format with BEGIN/END markers.
-pub fn encode_ssh_private_key(public_key: &[u8], private_key: &[u8]) -> Result<String> {
+pub fn encode_ssh_private_key(
+    public_key: &[u8],
+    private_key: &[u8],
+    comment: Option<&str>,
+) -> Result<String> {
     // Create the binary blob for the private key
     let mut blob = Vec::new();
 
@@ -62,7 +66,8 @@ pub fn encode_ssh_private_key(public_key: &[u8], private_key: &[u8]) -> Result<S
     write_length_prefixed_bytes(&mut private_blob, &private_key_data)?;
 
     // 7.5 Write comment
-    write_length_prefixed_string(&mut private_blob, DEFAULT_COMMENT)?;
+    let comment = comment.unwrap_or(DEFAULT_COMMENT);
+    write_length_prefixed_string(&mut private_blob, comment)?;
 
     // 7.6 Padding (pad to multiple of 8 bytes)
     let padding_len = 8 - (private_blob.len() % 8);


### PR DESCRIPTION
## Summary
- avoid double counting attempts in performance metrics
- generate ed25519 keys using `SigningKey::generate`
- allow customizing comment in generated private key

## Testing
- `cargo test --locked --quiet` *(fails: failed to get `anyhow` as a dependency)*
- `cargo test --locked --offline --quiet` *(fails: no matching package named `base64` found)*